### PR TITLE
example load helper function fixed, just identifies the file path to …

### DIFF
--- a/R/example.R
+++ b/R/example.R
@@ -10,11 +10,8 @@
 #' butcher_example("lm.rda")
 butcher_example <- function(path = NULL) {
   if (is.null(path)) {
-    output_path <- dir(system.file("extdata", package = "butcher"))
+    dir(system.file("extdata", package = "butcher"))
   } else {
-    output_path <- system.file("extdata", path, package = "butcher", mustWork = TRUE)
-    r_path <- paste0(unlist(strsplit(path, ".rda")), ".R")
-    cat(readChar(system.file("inst/extdata-scripts", r_path, package = "butcher", mustWork = TRUE), 1e5))
+    system.file("extdata", path, package = "butcher", mustWork = TRUE)
   }
-  return(output_path)
 }


### PR DESCRIPTION
…an example for testing, doesn't print the script used to generate the example object

Closes #3 

Example helper function is not exported, and will be utilized for testing each axe function works as expected for each modeling object. 